### PR TITLE
:wrench: Extend DNS configuration in test environment

### DIFF
--- a/config/test-dns.service.justice.gov.uk.yaml
+++ b/config/test-dns.service.justice.gov.uk.yaml
@@ -5,6 +5,12 @@
         health_check: 12345-abcdef
     ttl: 300
     type: A
+    value: example.com.
+  - octodns:
+      route53:
+        health_check: 12345-abcdef
+    ttl: 300
+    type: A
     value: 194.195.247.228
 
   - octodns:

--- a/config/test-dns.service.justice.gov.uk.yaml
+++ b/config/test-dns.service.justice.gov.uk.yaml
@@ -1,7 +1,6 @@
 ---
 '':
   - type: CNAME
-    ttl: 300
     value: example.com.
   - octodns:
       route53:

--- a/config/test-dns.service.justice.gov.uk.yaml
+++ b/config/test-dns.service.justice.gov.uk.yaml
@@ -1,8 +1,7 @@
 ---
 '':
-  - octodns:
+  - type: CNAME
     ttl: 300
-    type: CNAME
     value: example.com.
   - octodns:
       route53:

--- a/config/test-dns.service.justice.gov.uk.yaml
+++ b/config/test-dns.service.justice.gov.uk.yaml
@@ -4,7 +4,7 @@
       route53:
         health_check: 12345-abcdef
     ttl: 300
-    type: A
+    type: CNAME
     value: example.com.
   - octodns:
       route53:

--- a/config/test-dns.service.justice.gov.uk.yaml
+++ b/config/test-dns.service.justice.gov.uk.yaml
@@ -1,8 +1,6 @@
 ---
 '':
   - octodns:
-      route53:
-        health_check: 12345-abcdef
     ttl: 300
     type: CNAME
     value: example.com.


### PR DESCRIPTION
In this commit, we have extended the DNS configuration for our test environment (`test-dns.service.justice.gov.uk`). Specifically, a new A record has been added with TTL set to 300 and pointed towards `example.com.` The existing Route53 health check `12345-abcdef` is retained. These changes help in diversifying the DNS configurations for testing various scenarios.